### PR TITLE
pagination

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
 Suggests:
     testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    purrr
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1

--- a/R/boxr_misc.R
+++ b/R/boxr_misc.R
@@ -2,6 +2,7 @@
 #' 
 #' @param dir_id The box.com id for the folder that you'd like to query
 #' @param limit  Maximum number of entries to retrieve per query-page
+#' @param max    Maximum number of entries to retrieve in total
 #' 
 #' @return A data.frame describing the contents of the the folder specified by 
 #'   \code{dir_id}. Non recursive.
@@ -13,7 +14,7 @@
 #'   examining the contents of local directories.
 #'   
 #' @export
-box_ls <- function(dir_id = box_getwd(), limit = 100) {
+box_ls <- function(dir_id = box_getwd(), limit = 100, max = Inf) {
   
   # maybe some logic here to check that limit <= 1000
   
@@ -33,13 +34,51 @@ box_ls <- function(dir_id = box_getwd(), limit = 100) {
     limit = limit
   )
   
-  req <- httr::GET(
-    url,
-    httr::config(token = getOption("boxr.token"))
-  )
+  out <- box_pagination(url, max = max)
   
-  out <- httr::content(req)$entries
   class(out) <- "boxr_object_list"
+  return(out)
+}
+
+
+#' @keywords internal
+box_pagination <- function(url, max = 200) {
+  
+  out       <- list()
+  next_page <- TRUE
+  page      <- 1
+  n_so_far  <- 0
+  
+  while (next_page) {
+    
+    limit <- url$query$limit
+    
+    url$query$offset <- (page - 1) * limit
+    
+    req      <- httr::GET(
+      url, 
+      httr::config(token = getOption("boxr.token"))
+    )
+    
+    if (req$status_code == 404) {
+      message("box.com indicates that no results were found")
+      return()
+    }
+    
+    httr::stop_for_status(req)
+    
+    resp     <- httr::content(req)
+    n_req    <- length(resp$entries)
+    n_so_far <- n_so_far + n_req
+    total    <- resp$total_count
+    
+    if (!n_so_far < total | n_so_far >= max)
+      next_page <- FALSE
+    
+    out     <- c(out, resp$entries)
+    page    <- page + 1
+  }
+  
   return(out)
 }
 

--- a/man/box_ls.Rd
+++ b/man/box_ls.Rd
@@ -4,10 +4,14 @@
 \alias{box_ls}
 \title{Obtain a data.frame describing the contents of a box.com folder}
 \usage{
-box_ls(dir_id = box_getwd())
+box_ls(dir_id = box_getwd(), limit = 100, max = Inf)
 }
 \arguments{
 \item{dir_id}{The box.com id for the folder that you'd like to query}
+
+\item{limit}{Maximum number of entries to retrieve per query-page}
+
+\item{max}{Maximum number of entries to retrieve in total}
 }
 \value{
 A data.frame describing the contents of the the folder specified by 

--- a/man/box_search.Rd
+++ b/man/box_search.Rd
@@ -11,7 +11,7 @@ box_search(query = "", content_types = c("name", "description",
   "file_content", "comments", "tags"), type = NULL, file_extensions = NULL,
   ancestor_folder_ids = NULL, created_at_range = NULL,
   updated_at_range = NULL, size_range = NULL, trash = FALSE,
-  owner_user_ids = NULL, auto_paginate = TRUE, max = 200)
+  owner_user_ids = NULL, max = 200)
 
 box_search_files(query, ...)
 
@@ -50,11 +50,6 @@ A vector of two whole numbers (coerible via (coercible via
 
 \item{owner_user_ids}{Optional. Limit search to a files owned by a set of 
 users. A vector if IDs, coercible with \code{\link{as.integer64}}.}
-
-\item{auto_paginate}{\code{logical}. By default, the box.com will return a 
-fixed number of search results per request. By setting auto_paginate to 
-\code{TRUE}, boxr will keep making new requests untill all search results 
-are in.}
 
 \item{max}{\code{numeric}. Upper limit on the number of search results 
 returned (protective measure for users with large numbers of files).}

--- a/tests/testthat/test_12_ls.R
+++ b/tests/testthat/test_12_ls.R
@@ -1,0 +1,70 @@
+context("Listing remote files")
+
+# function to create a file in a local directory
+#
+# @param x    numeric, number of the file
+# @param dir  character, name of the directory
+#
+fn_create <- function(x, dir){
+  
+  name <- paste0("file_", formatC(x, width = 4, flag = "0"), ".txt")
+  filename <- file.path(dir_ls, name)
+  
+  writeLines("test file", filename)
+}
+
+# given a boxr_object_list, return a vector of names
+#
+# @param b boxr_object_list
+#
+get_filenames <- function(b){
+  b %>%
+    as.data.frame() %>%
+    dplyr::arrange(name) %>%
+    `[[`("name")
+}
+
+test_that("file listing works", {
+  
+  skip_on_cran()
+  boxr:::skip_on_travis()
+
+  # (Re)create local dir structure
+  boxr:::create_test_dir()
+  
+  # create ls directory
+  dir_ls <- file.path("test_dir", "ls")
+  dir.create(dir_ls)
+
+  # create files in the ls directory
+  purrr::walk(seq_len(10), fn_create, dir_ls)
+ 
+  files_local <- list.files(dir_ls)
+  
+  # push the local directory
+  box_push(0, "test_dir", overwrite = TRUE, delete = TRUE)
+  
+  # get the id of the remote ld directory
+  id_ls <- 
+    box_ls(0) %>%
+    as.data.frame() %>%
+    dplyr::filter(name == "ls") %>%
+    dplyr::select(id) %>%
+    `[[`(1) %>%
+    as.numeric()
+  
+  # get the listing without pagination
+  files_box <- 
+    box_ls(id_ls) %>% 
+    get_filenames()
+
+  # get the listing with pagination
+  files_box_page <-
+    box_ls(id_ls, limit = 5) %>%
+    get_filenames()
+  
+  # test
+  expect_identical(files_box, files_local)
+  expect_identical(files_box_page, files_local)
+ 
+})


### PR DESCRIPTION
Addresses #47

Please consider this as an opening, rather than as a closing.

I have not done any tests yet, other than to confirm that it works to list a directory with 443 files using `limit = 100` and `limit = 1000`, returning the same results.

I think that this function could be used with the search pagination, but it may mean tweaking the `box_search()` function a bit.

I'll think a bit about how to do the tests for this.