### PR TITLE
Change search type from plural to singular for file and folder search

### DIFF
--- a/R/boxr_search.R
+++ b/R/boxr_search.R
@@ -181,13 +181,13 @@ box_search <- function(
 #' @name box_search
 #' @export
 box_search_files <- function(query, ...) {
-  box_search(query, type = "files", ...)
+  box_search(query, type = "file", ...)
 }
 
 #' @name box_search
 #' @export
 box_search_folders <- function(query, ...) {
-  box_search(query, type = "folders", ...)
+  box_search(query, type = "folder", ...)
 }
 
 #' @name box_search


### PR DESCRIPTION
Was getting this error prior to this change:

``` r
library(boxr)
#> Welcome to boxr 0.3.4!
#> Bug reports & Getting Help: https://github.com/brendan-R/boxr/issues
box_auth()
#> Reading client id from .Renviron
#> Reading client secret from .Renviron
#> Warning in strptime(x, fmt, tz = "GMT"): unknown timezone 'default/America/
#> Vancouver'
#> boxr: Authenticated at box.com as Jas Sohi (jsohi@cardinalpath.com)
box_search_files("test")
#> Error in box_search(query, type = "files", ...): 'type' must be one of : file, folder, weblink
```