### PR TITLE
Tweaks to test

### DIFF
--- a/tests/testthat/test_02_clear_out.R
+++ b/tests/testthat/test_02_clear_out.R
@@ -4,6 +4,10 @@ context("Clear out")
 # Set up the local dir structure
 boxr:::create_test_dir()
 
+test_that("Local directory is created", {
+  expect_true(grepl("./test_dir", list.dirs(recursive = F)))
+})
+
 # Make sure the remote directory in the test account is clear
 test_that("Clear out the remote directory", {
   skip_on_cran()
@@ -13,4 +17,7 @@ test_that("Clear out the remote directory", {
   # Tell boxr to synch the remote home directory with an empty local one
   # (i.e. delete everything)
   b <- box_push(0, "test_dir/dir_12/dir_121/dir_1211", delete = TRUE)
+  
+  expect_length(box_ls(0), 0)
+  
 })

--- a/tests/testthat/test_12_ls.R
+++ b/tests/testthat/test_12_ls.R
@@ -8,7 +8,7 @@ context("Listing remote files")
 fn_create <- function(x, dir){
   
   name <- paste0("file_", formatC(x, width = 4, flag = "0"), ".txt")
-  filename <- file.path(dir_ls, name)
+  filename <- file.path(dir, name)
   
   writeLines("test file", filename)
 }

--- a/tests/testthat/test_99_tidy_up.R
+++ b/tests/testthat/test_99_tidy_up.R
@@ -1,7 +1,20 @@
-# Tidying up --------------------------------------------------------------
+context("Tidying up")
 
-# Synch the highest level box.com dir with an empty local one to clear it out
-b <- box_push(0, "test_dir/dir_12/dir_121/dir_1211", delete = TRUE)
+test_that("Box directory is emptied", {
+  skip_on_cran()
+  boxr:::skip_on_travis()
+  
+  # push empty local dir to top level on Box
+  b <- box_push(0, "test_dir/dir_12/dir_121/dir_1211", delete = TRUE)
+  
+  expect_equal(nrow(as.data.frame(box_ls(0))), 0)
+})
 
-# Remove the local dir
-unlink("test_dir", recursive = TRUE, force = TRUE)
+test_that("Local directory is deleted", {
+  skip_on_cran()
+  boxr:::skip_on_travis()
+  
+  unlink("test_dir", recursive = TRUE, force = TRUE)
+  
+  expect_equal(sum(grepl("test_dir", list.dirs(recursive = F))), 0)
+})


### PR DESCRIPTION
Added new tests and tweaked existing ones so not the only skipped test is the '#9 Search' (which might be removable due to Box's internal search indexing delay for new uploads).

The last commit is specifically about a warning in the `coveralls()` call after the `R CMD check` in the Travis Build

In reference to #76 and getting a CRAN release ready.