### PR TITLE
shared link bug fix

### DIFF
--- a/R/boxr_s3_classes.R
+++ b/R/boxr_s3_classes.R
@@ -99,7 +99,10 @@ print.boxr_file_reference <- function(x, ...) {
   )
   cat(" uploaded by :", x$modified_by$login, "\n")
   cat(" owned by    :", x$owned_by$login, "\n")
-  shared_link <- x$shared_link
+  if (is.list(x$shared_link))
+    shared_link <- x$shared_link$url
+  if (!is.list(x$shared_link))
+    shared_link <- x$shared_link
   if (is.null(shared_link))
     shared_link <- "None"
   cat(" shared link :", shared_link, "\n\n")


### PR DESCRIPTION
x$shared_link was coming through as a list and causing an error with subsequent cat() call. This fix selects the url item from that list (if x$shared_link is a list).