### PR TITLE
use viewer based credentials on Posit connectcreds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,14 +6,14 @@ Authors@R: c(
     person("Brendan", "Rocks", email = "foss@brendanrocks.com",
            role = c("aut")),
     person(
-      given = "Ian", 
-      family = "Lyttle", 
-      email = "ijlyttle@me.com", 
-      role = c("aut", "cre"), 
+      given = "Ian",
+      family = "Lyttle",
+      email = "ijlyttle@me.com",
+      role = c("aut", "cre"),
       comment = c(ORCID = "0000-0001-9962-4849")
     ),
     person(
-      given = "Nathan", 
+      given = "Nathan",
       family  = "Day",
       email = "nathancday@gmail.com",
       role = "aut",
@@ -65,7 +65,8 @@ Suggests:
     sodium,
     testthat,
     usethis,
-    covr
+    covr,
+    connectcreds
 VignetteBuilder: knitr
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -150,9 +150,12 @@ box_datetime <- function(x) {
 }
 
 checkAuth <- function() {
-  if (is.null(getOption("boxr.token") %||% getOption("boxr_token_jwt")))
-    stop("It doesn't look like you've set up authentication for boxr yet.\n",
-         "See ?box_auth or ?box_auth_jwt")
+  if (is.null(getOption("boxr.token") %||% getOption("boxr_token_jwt"))) {
+    if (!(rlang::is_installed("connectcreds") && connectcreds::has_viewer_token())) {
+      stop("It doesn't look like you've set up authentication for boxr yet.\n",
+           "See ?box_auth or ?box_auth_jwt")
+    }
+  }
 }
 
 
@@ -461,4 +464,25 @@ stack_rows_df <- function(list_x) {
   do.call(rbind, lapply(list_x, stack_row_df))
 }
 
+httr2_to_httr_token <- function(httr2_token) {
+  if (!inherits(httr2_token, "httr2_token")) {
+    stop("Input must be an httr2_token object", call. = FALSE)
+  }
 
+  app <- 
+    httr::oauth_app(
+      appname = "boxr",
+      key     = NULL,
+      secret  = NULL,
+    )
+  
+  token <- 
+    httr::oauth2.0_token(
+      endpoint = NULL,
+      app = app,
+      credentials = httr2_token,
+      cache = FALSE
+    )
+  
+  token
+}

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -635,6 +635,11 @@ get_token <- function() {
   if (has_jwt_token()) {
     return(getOption("boxr_token_jwt"))
   }
+
+  if (rlang::is_installed("connectcreds") && connectcreds::has_viewer_token()) {
+    token <- connectcreds::connect_viewer_token()
+    return(httr::config(token = httr2_to_httr_token(token)))
+  }
   
   stop("No token available", call. = FALSE)
 }


### PR DESCRIPTION
Works to resolve this issue, https://github.com/r-box/boxr/issues/274.

This is using the the [`{connectcreds}` package](https://github.com/posit-dev/connectcreds) which builds off `{httr2}` so some conversation is necessary in order to get a token that `{httr}` (and so the rest of this package) can consume. If this is not desired I can re-write to use the flow described in https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-viewer-oauth-access-token. Using `{connectcreds}` was mostly inspired by [similar functionality in the `{gh}` package](https://github.com/r-lib/gh/pull/217/files).